### PR TITLE
refactor: improve typings

### DIFF
--- a/src/contexts/settings.tsx
+++ b/src/contexts/settings.tsx
@@ -1,8 +1,8 @@
 import React, { createContext, FC, useContext } from 'react'
-import { DesignTokens } from '../utils/styles/designTokens'
+import { RawDesignTokens } from '../utils/styles/designTokens'
 
 type SettingsProps = {
-    designTokens?: DesignTokens
+    designTokens?: RawDesignTokens
 }
 
 type SettingsProviderProps = {

--- a/src/utils/styles/designTokens.ts
+++ b/src/utils/styles/designTokens.ts
@@ -47,7 +47,7 @@ type TokenFontSizes = {
 }
 
 type TokenLineHeights = {
-    [key: string]: string | number
+    [key: string]: number
 }
 
 type TokenColors = {
@@ -70,6 +70,10 @@ type Pixels<T extends { [key: string]: number }> = {
     [key in keyof T]: `${number}px`
 }
 
+type Stringify<T extends { [key: string]: number }> = {
+    [key in keyof T]: string
+}
+
 export type TokenComponents = {
     [componentName: string]: {
         [key: string]:
@@ -84,7 +88,7 @@ export type DesignTokens = {
     fonts: TokenFonts
     fontWeights: TokenFontWeights
     fontSizes: TokenFontSizes
-    lineHeights: TokenLineHeights
+    lineHeights: TokenLineHeights | Stringify<TokenLineHeights>
     letterSpacings: TokenLetterSpacings | Pixels<TokenLetterSpacings>
     colors: TokenColors
     components: TokenComponents
@@ -116,12 +120,14 @@ export type RawDesignTokens = DesignTokens & {
     spacings: TokenSpacings
     letterSpacings: TokenLetterSpacings
     radii: TokenRadii
+    lineHeights: TokenLineHeights
 }
 
 export type GeneratedDesignTokens = DesignTokens & {
     spacings: Pixels<TokenSpacings>
     letterSpacings: Pixels<TokenLetterSpacings>
     radii: Pixels<TokenRadii>
+    lineHeights: Stringify<TokenLineHeights>
 }
 
 export const SYSTEM_FONTS_FALLBACK =

--- a/src/utils/styles/globalStyles.ts
+++ b/src/utils/styles/globalStyles.ts
@@ -1,8 +1,14 @@
 import { css, SerializedStyles } from '@emotion/react'
-import { DesignTokens, ResponsiveTokens, TokenComponents } from './designTokens'
+import {
+    RawDesignTokens,
+    ResponsiveTokens,
+    TokenComponents
+} from './designTokens'
 import { from, until } from '../breakpoints'
 
-const renderTokens = (tokens: DesignTokens | ResponsiveTokens = {}): string =>
+const renderTokens = (
+    tokens: RawDesignTokens | ResponsiveTokens = {}
+): string =>
     Object.entries(tokens)
         .filter(
             ([namespace]) =>
@@ -38,7 +44,7 @@ export const generateGlobalStyles = ({
     customVariables,
     customReset
 }: {
-    designTokens: DesignTokens
+    designTokens: RawDesignTokens
     customVariables: SerializedStyles
     customReset: SerializedStyles
 }) => css`


### PR DESCRIPTION
Verbessert die Typisierung der designTokens.

Problem:

Vorher wurden in [`generateDesignTokens`](https://github.com/authentiqagency/q-core/blob/07ce38032f3e01ba97b19b138695506bb7d80ba3/src/utils/styles/designTokens.ts#L457-L486) die `const settings` mit den generierten tokens in der selben variable überschrieben. Deshalb hatten die Tokens, die später in pixel konvertiert wurden, die Typisierung `number | string`.

z.B.

```ts
type TokenLetterSpacings = {
    [key: 'default' | Heading | string]: number | string
}
```

Zudem mussten wir für die korrekte Berechnung der weiteren Werte die originalen settings [klonen](https://github.com/authentiqagency/q-core/blob/07ce38032f3e01ba97b19b138695506bb7d80ba3/src/utils/styles/designTokens.ts#L462-L464):

```ts
    const originalSpacings = { ...settings.spacings }
    const originalFontSizes = { ...settings.fontSizes }
    const originalLineHeights = { ...settings.lineHeights }
```

Mit diesem PR wird `const settings` nicht mehr überschrieben und die Typisierung dadurch klarer und sauberer.
